### PR TITLE
refactor: Splits constructor args of PullRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can find the exhaustive list of supported features in the [documentation](ht
 ```python
 from ghapi_client.pulls import PullRequest
 
-pr = PullRequest("frgfm/torch-cam", 187)
+pr = PullRequest("frgfm", "torch-cam", 187)
 # Get the PR information
 pr.get_info()
 ```

--- a/ghapi_client/pulls.py
+++ b/ghapi_client/pulls.py
@@ -11,7 +11,7 @@ from .exceptions import HTTPRequestException
 
 __all__ = ["PullRequest"]
 
-ROUTE_URL = "https://api.github.com/repos/{repo_name}/pulls/{pr_num}"
+ROUTE_URL = "https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}"
 
 
 def parse_diff_body(diff_body: str) -> Dict[str, List[Tuple[str, str]]]:
@@ -36,17 +36,19 @@ class PullRequest:
     """Implements a Pull Request object
 
     >>> from ghapi_client.pulls import PullRequest
-    >>> pr = PullRequest("frgfm/torch-cam", 187)
+    >>> pr = PullRequest("frgfm", "torch-cam", 187)
     >>> pr.get_info()
 
     Args:
-        repo_name: the full repository name
-        pr_num: the PR number
+        owner: GitHub login of the repository's owner
+        repo: name of the repository
+        pull_number: the PR number
     """
 
-    def __init__(self, repo_name: str, pr_num: int) -> None:
-        self.repo_name = repo_name
-        self.pr_num = pr_num
+    def __init__(self, owner: str, repo: str, pull_number: int) -> None:
+        self.owner = owner
+        self.repo = repo
+        self.pull_number = pull_number
         self.reset()
 
     def reset(self) -> None:
@@ -56,7 +58,7 @@ class PullRequest:
     @property
     def info(self) -> Dict[str, Any]:
         if not isinstance(self._info, dict):
-            response = requests.get(ROUTE_URL.format(repo_name=self.repo_name, pr_num=self.pr_num))
+            response = requests.get(ROUTE_URL.format(owner=self.owner, repo=self.repo, pull_number=self.pull_number))
             if response.status_code != 200:
                 raise HTTPRequestException(response.status_code, response.text)
 
@@ -88,7 +90,7 @@ class PullRequest:
     def diff(self) -> str:
         if not isinstance(self._diff, str):
             response = requests.get(
-                ROUTE_URL.format(repo_name=self.repo_name, pr_num=self.pr_num),
+                ROUTE_URL.format(owner=self.owner, repo=self.repo, pull_number=self.pull_number),
                 headers={"Accept": "application/vnd.github.v4.diff"},
             )
             if response.status_code != 200:

--- a/tests/test_pulls.py
+++ b/tests/test_pulls.py
@@ -29,28 +29,28 @@ def test_parse_diff_body(diff_body, expected_parsing):
 
 
 @pytest.mark.parametrize(
-    "repo_name, pr_num, payload_len, created_at",
+    "owner, repo, pr_num, payload_len, created_at",
     [
-        ["frgfm/torch-cam", 115, 11, "2021-11-14T16:12:44Z"],
-        ["frgfm/torch-cam", 187, 11, "2022-09-18T17:08:50Z"],
+        ["frgfm", "torch-cam", 115, 11, "2021-11-14T16:12:44Z"],
+        ["frgfm", "torch-cam", 187, 11, "2022-09-18T17:08:50Z"],
     ],
 )
-def test_pull_request_get_info(repo_name, pr_num, payload_len, created_at):
-    pr = PullRequest(repo_name, pr_num)
+def test_pull_request_get_info(owner, repo, pr_num, payload_len, created_at):
+    pr = PullRequest(owner, repo, pr_num)
     out = pr.get_info()
     assert len(out) == payload_len
     assert out["created_at"] == created_at
 
 
 @pytest.mark.parametrize(
-    "repo_name, pr_num, num_files, num_sections",
+    "owner, repo, pr_num, num_files, num_sections",
     [
-        ["frgfm/torch-cam", 115, 1, 1],
-        ["frgfm/torch-cam", 187, 3, 8],
+        ["frgfm", "torch-cam", 115, 1, 1],
+        ["frgfm", "torch-cam", 187, 3, 8],
     ],
 )
-def test_pull_request_get_diff(repo_name, pr_num, num_files, num_sections):
-    pr = PullRequest(repo_name, pr_num)
+def test_pull_request_get_diff(owner, repo, pr_num, num_files, num_sections):
+    pr = PullRequest(owner, repo, pr_num)
     out = pr.get_diff()
     assert len(out) == num_files
     assert sum(len(sections) for sections in out.values()) == num_sections


### PR DESCRIPTION
This PR introduces the following modifications:
- splits args `repo_name` into `owner` and `repo` to git Github API args
- updates tests
- updates README